### PR TITLE
Linter påkrever strict-mode før oppgaven ber en sette det på.

### DIFF
--- a/exercise-4/.eslintrc.json
+++ b/exercise-4/.eslintrc.json
@@ -6,6 +6,6 @@
     "semi": "error",
     "brace-style": "error",
     "eqeqeq": "error",
-    "vars-on-top": "error",
+    "vars-on-top": "error"
   }
 }

--- a/exercise-4/.eslintrc.json
+++ b/exercise-4/.eslintrc.json
@@ -7,6 +7,5 @@
     "brace-style": "error",
     "eqeqeq": "error",
     "vars-on-top": "error",
-    "strict": ["error", "global"]
   }
 }


### PR DESCRIPTION
Fjernet strict-regelen i eslint-regelsettet for exercise 4. Om den er der får man ikke kjøre koden i exercise 4 1.0 og man må sette på strict mode før man får beskjed om det i 1.1.